### PR TITLE
Fix example doc - Audio Emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ import { AudioListener } from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
 import { GLTFAudioEmitterExtension } from "three-omi";
 
-
 // The extension needs a reference to your player's AudioEmitter
 const audioListener = new AudioListener();
 


### PR DESCRIPTION
I think this line needs to be added to the example docs to allow GLTFAudioEmitterExtension to be used.