### PR TITLE
reverts package version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-omi",
-  "version": "0.1.5",
+  "version": "0.1.4",
   "license": "MIT",
   "author": {
     "name": "The Open Metaverse Interoperability Group",


### PR DESCRIPTION
Note to self: lets bump these in the future using `npm version patch` Need to keep main in line with the correct version in order to bump it proper so we need to revert first.